### PR TITLE
Update

### DIFF
--- a/lda.py
+++ b/lda.py
@@ -144,7 +144,7 @@ print(model, "\n")
 topics = model.show_topics(num_topics=no_of_topics)
 
 for item, i in zip(topics, enumerate(topics)):
-    print("topic #"+str(i[0])+": "+item+"\n")
+    print("topic #"+str(i[0])+": "+str(item)+"\n")
 
 
 print("saving ...\n")
@@ -156,7 +156,7 @@ with open("out/"+foldername+"_doclabels.txt", "w") as f:
 
 with open("out/"+foldername+"_topics.txt", "w") as f:
     for item, i in zip(topics, enumerate(topics)):
-        f.write("topic #"+str(i[0])+": "+item+"\n")
+        f.write("topic #"+str(i[0])+": "+str(item)+"\n")
 
 dictionary.save("out/"+foldername+".dict")
 MmCorpus.serialize("out/"+foldername+".mm", corpus)

--- a/lda_heatmap.py
+++ b/lda_heatmap.py
@@ -42,7 +42,7 @@ for doc, i in zip(corpus, range(no_of_docs)):           # use document bow from 
 
 topic_labels = []
 for i in range(no_of_topics):
-    topic_terms = [x[1] for x in model.show_topic(i, topn=3)]           # show_topic() returns tuples (word_prob, word)
+    topic_terms = [x[0] for x in model.show_topic(i, topn=3)]           # show_topic() returns tuples (word_prob, word)
     topic_labels.append(" ".join(topic_terms))
 
 #print(doc_topic)


### PR DESCRIPTION
Lieber Stefan,

da gensim v0.12.4 jetzt auch bei 0 anfängt zu zählen (und nicht bei 1 wie in früheren Versionen, als du das Skript geschrieben hast), habe ich das mal aktualisiert (da sonst in der Visualisierung die x-Achse mit der Topic ID und nicht dem Topic selbst beschriftet wird).
Bei der Speicherung der Topics _ohne explizite String Konvertierung_ habe ich außerdem `TypeError: Can't convert 'tuple' object to str implicitly` bekommen.
Ich korrigiere das auch gerne im Tutorial (und dass man eben mindestens gensim v0.12.4 braucht)!

Viele Grüße, Severin
